### PR TITLE
Add Eclipse specific files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@ info
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# Eclipse #
+.classpath
+.project
+.settings/


### PR DESCRIPTION
This PR adds some Eclipse specific files (e.g. .project) to the list of files that git ignores. This means that for example .project won't show up as an untracked file when importing the project into the Eclipse IDE.