### PR TITLE
Dependency cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,11 +153,6 @@
       <version>1.0.4</version>
     </dependency>
     <dependency>
-      <groupId>org.glassfish.jersey.core</groupId>
-      <artifactId>jersey-common</artifactId>
-      <version>2.20</version>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
       <version>1.9.5</version>

--- a/pom.xml
+++ b/pom.xml
@@ -143,45 +143,9 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.glassfish.hk2</groupId>
-      <artifactId>hk2-api</artifactId>
-      <version>2.4.0-b27</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.hk2</groupId>
-      <artifactId>hk2-locator</artifactId>
-      <version>2.4.0-b27</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.hk2</groupId>
-      <artifactId>hk2-utils</artifactId>
-      <version>2.4.0-b27</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <version>4.4</version>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.hk2.external</groupId>
-      <artifactId>javax.inject</artifactId>
-      <version>2.4.0-b27</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.hk2.external</groupId>
-      <artifactId>aopalliance-repackaged</artifactId>
-      <version>2.4.0-b27</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>javaee</groupId>
-      <artifactId>javaee-api</artifactId>
-      <version>5</version>
-      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>
@@ -192,12 +156,6 @@
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-common</artifactId>
       <version>2.20</version>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.jersey.bundles.repackaged</groupId>
-      <artifactId>jersey-guava</artifactId>
-      <version>2.20</version>
-      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -166,11 +166,6 @@
       <version>4.4</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpcore</artifactId>
-      <version>4.4</version>
-    </dependency>
-    <dependency>
       <groupId>org.glassfish.hk2.external</groupId>
       <artifactId>javax.inject</artifactId>
       <version>2.4.0-b27</version>

--- a/src/test/java/org/piwik/java/tracking/PiwikTrackerTest.java
+++ b/src/test/java/org/piwik/java/tracking/PiwikTrackerTest.java
@@ -72,7 +72,7 @@ public class PiwikTrackerTest{
         HttpResponse response = mock(HttpResponse.class);
         
         doReturn(client).when(piwikTracker).getHttpClient();
-        doReturn("query").when(request).getUrlEncodedQueryString();
+        doReturn("query").when(request).getQueryString();
         doReturn(response).when(client).execute(argThat(new CorrectGetRequest("http://test.com?query")));
         
         assertEquals(response, piwikTracker.sendRequest(request));


### PR DESCRIPTION
This PR is a series of commits that fix issue #23.

The first commit removes the need for the jersey-common UriBuilder class. The second commit fixes a test for commit 1. The third commit removes the explicit httpcore dependency since it's a transitive dependency of httpclient. The fourth commit removes all the runtime dependencies since they seem to be unused - as far as I can tell and as far as the tests are concerned. The fifth commit removes the jersey-common dependency since the UriBuilder is not used anymore.

The most controversial commit is probably the removal of all the runtime dependencies since I am not sure whether the test cases cover that scenario.